### PR TITLE
Provide option to vary regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@ var PluginError = gutil.PluginError;
 var PLUGIN_NAME = 'gulp-remove-html';
 var indices = [];
 
-function gulpRemoveHtml(){
+function gulpRemoveHtml(options){
+    var options = options || {};
     var stream = through2.obj(function(chunk, enc, cb){
         //Does not support Streams
        if(chunk.isStream()){
@@ -17,7 +18,8 @@ function gulpRemoveHtml(){
             The regular expression searches for a pattern that matches the open closing tags of deject.
             NOTE That these tags must be commented out for the plugin to reconise them.
             */
-            var dejectPatternRegex =/<!--\s*<(?:\/)?[Deject]+>\s*-->/ig;
+            var dejectPatternRegex = /<!--\s*<(?:\/)?[Deject]+>\s*-->/ig;
+            if(options.dejectPatternRegex) dejectPatternRegex = options.dejectPatternRegex;
             var result;
             while ((result = dejectPatternRegex.exec(fileContents))) {
               if (indices.length % 2) {


### PR DESCRIPTION
Hello. I mainly wanted to change the name of the string in the middle of the comment so I could have <!-- removeThis --> as well as <!--Deject-->. I think passing a string and building the regex using new RegExp() would be more user friendly but I couldn't get it to work.  Instead, I've just allowed the whole regex to be overwritten.
